### PR TITLE
Restrict donations in USD, GBP and EUR to 10

### DIFF
--- a/donate/core/tests/test_models.py
+++ b/donate/core/tests/test_models.py
@@ -147,37 +147,37 @@ class CampaignPageTestCase(TestCase):
         )
 
     def test_get_initial_currency_info_as_specified(self):
-        request = RequestFactory().get('/?presets=2,9,5,3')
+        request = RequestFactory().get('/?presets=10,12,15,18')
         self.assertEqual(
             DonationPage().get_initial_currency_info(request, 'usd', 'single')['presets']['single'],
-            [Decimal(2), Decimal(9), Decimal(5), Decimal(3)]
+            [Decimal(10), Decimal(12), Decimal(15), Decimal(18)]
         )
 
     def test_get_initial_currency_info_reverse_sorted(self):
-        request = RequestFactory().get('/?presets=2,9,5,3&sort=reverse')
+        request = RequestFactory().get('/?presets=10,12,15,18&sort=reverse')
         self.assertEqual(
             DonationPage().get_initial_currency_info(request, 'usd', 'single')['presets']['single'],
-            [Decimal(9), Decimal(5), Decimal(3), Decimal(2)]
+            [Decimal(18), Decimal(15), Decimal(12), Decimal(10)]
         )
 
     def test_get_initial_currency_info_ignore_bad_values(self):
-        request = RequestFactory().get('/?presets=-1,0,1,2,3,4,5')
+        request = RequestFactory().get('/?presets=-1,0,1,2,3,4,5,10')
         initial_currency_info = DonationPage().get_initial_currency_info(request, 'usd', 'single')['presets']['single']
         self.assertEqual(len(initial_currency_info), 4)
 
     def test_get_initial_currency_info_at_least_four_choices(self):
-        request = RequestFactory().get('/?presets=5')
+        request = RequestFactory().get('/?presets=10')
         default_single = DonationPage().currencies['usd']['presets']['single']
         self.assertEqual(
             DonationPage().get_initial_currency_info(request, 'usd', 'single')['presets']['single'],
             default_single
         )
-        request = RequestFactory().get('/?presets=5,5')
+        request = RequestFactory().get('/?presets=10,10')
         self.assertEqual(
             DonationPage().get_initial_currency_info(request, 'usd', 'single')['presets']['single'],
             default_single
         )
-        request = RequestFactory().get('/?presets=5,5,5')
+        request = RequestFactory().get('/?presets=10,10,10')
         self.assertEqual(
             DonationPage().get_initial_currency_info(request, 'usd', 'single')['presets']['single'],
             default_single

--- a/donate/payments/constants.py
+++ b/donate/payments/constants.py
@@ -41,7 +41,7 @@ CURRENCIES = {
     },
     'aud': {
         'code': 'aud',
-        'minAmount': 3,
+        'minAmount': 10,
         'symbol': '$',
         'disabled': ['amex'],
         'paypalFixedFee': {
@@ -58,7 +58,7 @@ CURRENCIES = {
         ],
         'presets': {
             'single': [10, 20, 30, 60],
-            'monthly': [5, 10, 15, 20],
+            'monthly': [10, 15, 20, 25],
         }
     },
     'brl': {
@@ -85,7 +85,7 @@ CURRENCIES = {
     },
     'cad': {
         'code': 'cad',
-        'minAmount': 3,
+        'minAmount': 10,
         'symbol': '$',
         'disabled': ['amex'],
         'paypalFixedFee': {
@@ -102,7 +102,7 @@ CURRENCIES = {
         ],
         'presets': {
             'single': [10, 20, 30, 60],
-            'monthly': [5, 10, 15, 20],
+            'monthly': [10, 15, 20, 25],
         }
     },
     'chf': {

--- a/donate/payments/constants.py
+++ b/donate/payments/constants.py
@@ -20,7 +20,7 @@ METHODS = (METHOD_CARD, METHOD_PAYPAL)
 CURRENCIES = {
     'usd': {
         'code': 'usd',
-        'minAmount': 2,
+        'minAmount': 10,
         'symbol': '$',
         'paypalFixedFee': {
             'macro': 0.30,
@@ -36,7 +36,7 @@ CURRENCIES = {
         ],
         'presets': {
             'single': [10, 20, 30, 60],
-            'monthly': [5, 10, 15, 20],
+            'monthly': [10, 15, 20, 25],
         }
     },
     'aud': {
@@ -173,7 +173,7 @@ CURRENCIES = {
     },
     'eur': {
         'code': 'eur',
-        'minAmount': 2,
+        'minAmount': 10,
         'symbol': '€',
         'disabled': ['amex'],
         'paypalFixedFee': {
@@ -189,12 +189,12 @@ CURRENCIES = {
         ],
         'presets': {
             'single': [10, 20, 30, 60],
-            'monthly': [5, 10, 15, 20],
+            'monthly': [10, 15, 20, 25],
         }
     },
     'gbp': {
         'code': 'gbp',
-        'minAmount': 2,
+        'minAmount': 10,
         'symbol': '£',
         'disabled': ['amex'],
         'paypalFixedFee': {
@@ -211,7 +211,7 @@ CURRENCIES = {
         ],
         'presets': {
             'single': [10, 20, 30, 60],
-            'monthly': [5, 10, 15, 20]
+            'monthly': [10, 15, 20, 25]
         }
     },
     'hkd': {

--- a/donate/payments/tests/test_forms.py
+++ b/donate/payments/tests/test_forms.py
@@ -14,9 +14,9 @@ class MinimumCurrencyAmountMixinTestCase(TestCase):
 
     def test_init_sets_min_attr_if_currency_supplied(self):
         form = MinimumCurrencyTestForm(currency='usd')
-        self.assertEqual(form.fields['amount'].widget.attrs['min'], 2)
+        self.assertEqual(form.fields['amount'].widget.attrs['min'], 10)
 
     def test_clean_validates_minimum_amount(self):
         form = MinimumCurrencyTestForm({'amount': 1, 'currency': 'usd'})
         self.assertFalse(form.is_valid())
-        self.assertEqual(form.errors, {'amount': ['Donations must be $2 or more']})
+        self.assertEqual(form.errors, {'amount': ['Donations must be $10 or more']})

--- a/donate/templates/fragments/donate_form.html
+++ b/donate/templates/fragments/donate_form.html
@@ -43,7 +43,7 @@
                         </div>
                         <p class='minimum'>
                             {% format_currency request.LANGUAGE_CODE initial_currency_info.code initial_currency_info.minAmount as minimum_amount %}
-                            {% blocktrans with min_amount=minimum_amount trimmed %}Minimum amount is {{ min_amount }}{% endblocktrans %}
+                            {% blocktrans with min_amount=minimum_amount trimmed %}To combat fraud, Mozilla Foundation has temporarily restricted donations to a mininum of {{ min_amount }}{% endblocktrans %}
                         </p>
                         <p id='other-one-time-amount-error-message' class='error-message hidden'>
                             {% trans "Invalid amount entered." %}

--- a/donate/templates/fragments/donate_form.html
+++ b/donate/templates/fragments/donate_form.html
@@ -43,7 +43,7 @@
                         </div>
                         <p class='minimum'>
                             {% format_currency request.LANGUAGE_CODE initial_currency_info.code initial_currency_info.minAmount as minimum_amount %}
-                            {% blocktrans with min_amount=minimum_amount trimmed %}To combat fraud, Mozilla Foundation has temporarily restricted donations to a mininum of {{ min_amount }}{% endblocktrans %}
+                            {% blocktrans with min_amount=minimum_amount trimmed %}To combat fraud, Mozilla Foundation has temporarily restricted donations to a minimum of {{ min_amount }}{% endblocktrans %}
                         </p>
                         <p id='other-one-time-amount-error-message' class='error-message hidden'>
                             {% trans "Invalid amount entered." %}

--- a/source/js/components/currency-selector.js
+++ b/source/js/components/currency-selector.js
@@ -96,7 +96,9 @@ class CurrencySelect {
       .join("");
 
     var otherAmountString = window.gettext("Other amount");
-    var minimumOtherAmountString = window.gettext("To combat fraud, Mozilla Foundation has temporarily restricted donations to a minimum of");
+    var minimumOtherAmountString = window.gettext(
+      "To combat fraud, Mozilla Foundation has temporarily restricted donations to a minimum of"
+    );
     var invalidAmountString = window.gettext("Invalid amount entered.");
     var formattedMinimumValue = formatter.format(minAmount);
 

--- a/source/js/components/currency-selector.js
+++ b/source/js/components/currency-selector.js
@@ -96,7 +96,7 @@ class CurrencySelect {
       .join("");
 
     var otherAmountString = window.gettext("Other amount");
-    var minimumOtherAmountString = window.gettext("Minimum amount is");
+    var minimumOtherAmountString = window.gettext("To combat fraud, Mozilla Foundation has temporarily restricted donations to a minimum of");
     var invalidAmountString = window.gettext("Invalid amount entered.");
     var formattedMinimumValue = formatter.format(minAmount);
 


### PR DESCRIPTION
Can be rolled back when other fraud mitigation methods are implemented. 

Affects monthly donations as the same logic is used to determine minimum so the available preset donations has also been changed.

Messaging updated to describe the reasoning behind the minimum.
