### PR TITLE
updated all references of master branch to main

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,7 +11,7 @@ _Remove unnecessary checks_
 **Changes in Models:**
 - [ ] Did I update or add new fake data?
 - [ ] Did I squash my migration?
-- [ ] [Are my changes backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/master/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?
+- [ ] [Are my changes backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?
 
 **Documentation:**
 - [ ] Is my code documented?

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -2,9 +2,9 @@ name: Continuous Integration
 
 on:
   push:
-    branches: [ 'master' ]
+    branches: [ 'main' ]
   pull_request:
-    branches: [ 'master' ]
+    branches: [ 'main' ]
 
 jobs:
   test_node:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # donate-wagtail
 
-[![Build Status](https://travis-ci.org/mozilla/donate-wagtail.svg?branch=master)](https://travis-ci.org/mozilla/donate-wagtail)
+[![Build Status](https://travis-ci.org/mozilla/donate-wagtail.svg?branch=main)](https://travis-ci.org/mozilla/donate-wagtail)
 
 ## Table of contents
 
@@ -203,7 +203,7 @@ The latest UI source strings are regularly exposed to Pontoon by a Localization 
 - Set the `LOCAL_PATH_TO_L10N_REPO` variable in your `.env` file. Use the absolute path to your copy of the `donate-l10n` repository and include the trailing slash. E.g. `LOCAL_PATH_TO_L10N_REPO=/Users/username/Documents/GitHub/donate-l10n/`
 
 ### Exposing latest source strings:
-- Make sure your local repositories of `donate-l10n` and `donate-wagtail` are matching the latest revision from master.
+- Make sure your local repositories of `donate-l10n` and `donate-wagtail` are matching the latest revision from main.
 - Run `inv docker-makemessages` from your `donate-wagtail` repository.
 - Files should have been updated in your `donate-l10n` repository. You can now create a pull-request.
 

--- a/docs/pontoon_integration.md
+++ b/docs/pontoon_integration.md
@@ -30,7 +30,7 @@ A scheduled task runs every 20 minutes to sync the donate platform with the `moz
 
 The initial sync needs to be run manually:
 
-- **If the content repo is empty:** `touch README.md` and push this file to the master branch of the content repo.
+- **If the content repo is empty:** `touch README.md` and push this file to the main branch of the content repo.
 - run `heroku login`.
 - run `heroku run bash -a donate-wagtail-production`.
 - run `python manage.py sync_languages`: creates `Language` objects for all languages defined in the `LANGUAGES` section of `settings.py`.


### PR DESCRIPTION
Related PRs/issues #1568

This PR updates any reference of the word 'master' to the new default branch name 'main'.

Please note that since this PR updates the CI file, the tests will not run. That is to be expected. If you would like to test, please pull this PR into your local machine and run `inv test-python`.

However, here is a screenshot of when I run the same command:
<img width="979" alt="image" src="https://user-images.githubusercontent.com/18314510/195219225-21ad40a7-02cd-4e47-96f6-8b5f4255dc55.png">

