### PR TITLE
#9505 #1711 Reduce smallest monthly preset from 10 to 5 for USD, EUR and GPB

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 When it's done, run `docker-compose up`, wait for the static files to be built, and go to `0.0.0.0:8000`. When you want to stop, do `^C` to shut down your containers. If they don't stop properly, run `docker-compose down`. If you want a new dev environment, stop your containers and run `inv new_env`.
 
-Secrets necessary to enable several features in a local docker development environment can be found in the 1pass, Engagement Vault, in a Note called "donate-wagtail docker .env file".  Copy the contents of this file and replace the .env file that came with the repo.  Do not distrubute the .env file.  
+Secrets necessary to enable several features in a local docker development environment can be found in the 1pass, Engagement Vault, in a Note called "donate-wagtail docker .env file".  Copy the contents of this file and replace the .env file that came with the repo.  Do not distrubute the .env file.
 
 It's possible to connect your IDE to the python virtual env available inside the backend container (tested with pycharm and vscode). If you run into issues, ping patjouk on slack.
 
@@ -47,7 +47,6 @@ More information on how to use Docker for local dev is available in the [Local d
 
 To set the Thunderbird settings in local development, simply change your `DJANGO_CONFIGURATION` in your .env file to be one of the choices above (For Thunderbird, use `ThunderbirdDevelopment`)
 
-
 ## Braintree configuration
 
 The following environment variables are required to configure payment processing via Braintree:
@@ -59,6 +58,12 @@ The following environment variables are required to configure payment processing
 - `BRAINTREE_PRIVATE_KEY`: Private API key provided by Braintree.
 - `BRAINTREE_TOKENIZATION_KEY`: Tokenization key provided by Braintree.
 - `BRAINTREE_USE_SANDBOX`: Boolean to configure whether or not to use the Braintree sandbox.
+
+To get the payment processing working during local development, check 1Password for an example configuration by searching for "donate-wagtail docker .env file".
+Without the Braintree configuration in place, you won't be able to see the PayPal button on the landing pages.
+
+You can also find example PayPal user credentials in 1Password by searching for "Paypal Sandbox Merchant".
+Use these as the login information during PayPal checkout.
 
 ### Webhook Configuration
 

--- a/donate/payments/forms.py
+++ b/donate/payments/forms.py
@@ -104,6 +104,7 @@ class PostalCodeMixin():
 class StartCardPaymentForm(MinimumCurrencyAmountMixin, forms.Form):
     amount = forms.DecimalField(label=_('Amount'), min_value=0.01, max_value=MAX_AMOUNT_VALUE, decimal_places=2)
     currency = forms.ChoiceField(choices=constants.CURRENCY_CHOICES)
+    frequency = forms.ChoiceField(choices=constants.FREQUENCY_CHOICES, widget=forms.HiddenInput)
     source_page_id = forms.IntegerField(widget=forms.HiddenInput)
 
     def clean_source_page_id(self):
@@ -166,6 +167,11 @@ class CurrencyForm(forms.Form):
 
 class UpsellForm(MinimumCurrencyAmountMixin, forms.Form):
     currency = forms.ChoiceField(choices=constants.CURRENCY_CHOICES, widget=forms.HiddenInput, disabled=True)
+    frequency = forms.ChoiceField(
+        choices=constants.FREQUENCY_CHOICES,
+        widget=forms.HiddenInput,
+        initial=constants.FREQUENCY_MONTHLY,
+    )
     amount = forms.DecimalField(
         label=_('Amount'), min_value=1, max_value=MAX_AMOUNT_VALUE, decimal_places=2,
         widget=forms.NumberInput(attrs={'step': 'any'})

--- a/donate/payments/forms.py
+++ b/donate/payments/forms.py
@@ -174,11 +174,16 @@ class UpsellForm(MinimumCurrencyAmountMixin, forms.Form):
         choices=constants.FREQUENCY_CHOICES,
         widget=forms.HiddenInput,
         initial=constants.FREQUENCY_MONTHLY,
+        required=False,
     )
     amount = forms.DecimalField(
         label=_('Amount'), min_value=1, max_value=MAX_AMOUNT_VALUE, decimal_places=2,
         widget=forms.NumberInput(attrs={'step': 'any'})
     )
+
+    def clean_frequency(self):
+        '''Always use monthly for the frequency.'''
+        return constants.FREQUENCY_MONTHLY
 
 
 class BraintreePaypalUpsellForm(UpsellForm, BraintreePaymentForm):

--- a/donate/payments/forms.py
+++ b/donate/payments/forms.py
@@ -11,7 +11,7 @@ from donate.core.templatetags.util_tags import format_currency
 from donate.recaptcha.fields import ReCaptchaField
 
 from . import constants
-from .utils import get_currency_info, get_min_amount_for_currency
+from . import utils
 
 from ..settings.environment import root
 
@@ -55,16 +55,19 @@ class MinimumCurrencyAmountMixin:
         frequency = self['frequency'].initial
 
         if currency and frequency:
-            min_amount = get_min_amount_for_currency(currency=currency, frequency=frequency)
+            min_amount = utils.get_min_amount_for_currency(currency=currency, frequency=frequency)
             self.fields['amount'].widget.attrs['min'] = min_amount
 
     def clean(self):
         cleaned_data = super().clean()
+
         amount = cleaned_data.get('amount', False)
         currency = cleaned_data.get('currency', False)
-        if amount and currency:
-            currency_info = get_currency_info(currency)
-            min_amount = currency_info['minAmount']
+        frequency = cleaned_data.get('frequency', False)
+
+        if amount and currency and frequency:
+            min_amount = utils.get_min_amount_for_currency(currency=currency, frequency=frequency)
+
             if amount < min_amount:
                 raise forms.ValidationError({
                     'amount': _('Donations must be %(amount)s or more') % {'amount': format_currency(

--- a/donate/payments/tests/test_forms.py
+++ b/donate/payments/tests/test_forms.py
@@ -13,11 +13,16 @@ class MinimumCurrencyTestForm(MinimumCurrencyAmountMixin, forms.Form):
 
 class MinimumCurrencyAmountMixinTestCase(TestCase):
 
-    def test_init_sets_min_attr_if_currency_supplied(self):
+    def test_init_sets_min_attr_if_currency_and_frequency_supplied(self):
         form = MinimumCurrencyTestForm(initial={'currency': 'usd', 'frequency': constants.FREQUENCY_SINGLE})
         self.assertEqual(form.fields['amount'].widget.attrs['min'], 10)
 
-    def test_clean_validates_minimum_amount(self):
-        form = MinimumCurrencyTestForm({'amount': 1, 'currency': 'usd'})
+    def test_clean_validates_minimum_amount_single(self):
+        form = MinimumCurrencyTestForm({'amount': 1, 'currency': 'usd', 'frequency': constants.FREQUENCY_SINGLE})
         self.assertFalse(form.is_valid())
         self.assertEqual(form.errors, {'amount': ['Donations must be $10 or more']})
+
+    def test_clean_validates_minimum_amount_monthly(self):
+        form = MinimumCurrencyTestForm({'amount': 1, 'currency': 'usd', 'frequency': constants.FREQUENCY_MONTHLY})
+        self.assertFalse(form.is_valid())
+        self.assertEqual(form.errors, {'amount': ['Donations must be $5 or more']})

--- a/donate/payments/tests/test_forms.py
+++ b/donate/payments/tests/test_forms.py
@@ -7,13 +7,14 @@ from ..forms import MinimumCurrencyAmountMixin
 
 class MinimumCurrencyTestForm(MinimumCurrencyAmountMixin, forms.Form):
     amount = forms.DecimalField()
-    currency = forms.ChoiceField(choices=constants.CURRENCY_CHOICES)
+    currency = forms.ChoiceField(choices=constants.CURRENCY_CHOICES, widget=forms.HiddenInput)
+    frequency = forms.ChoiceField(choices=constants.FREQUENCY_CHOICES, widget=forms.HiddenInput)
 
 
 class MinimumCurrencyAmountMixinTestCase(TestCase):
 
     def test_init_sets_min_attr_if_currency_supplied(self):
-        form = MinimumCurrencyTestForm(currency='usd')
+        form = MinimumCurrencyTestForm(initial={'currency': 'usd', 'frequency': constants.FREQUENCY_SINGLE})
         self.assertEqual(form.fields['amount'].widget.attrs['min'], 10)
 
     def test_clean_validates_minimum_amount(self):

--- a/donate/payments/tests/test_utils.py
+++ b/donate/payments/tests/test_utils.py
@@ -3,9 +3,14 @@ from decimal import Decimal
 from django.test import TestCase, override_settings
 
 from ..utils import (
-    determine_paypal_account, freeze_transaction_details_for_session, get_default_currency,
-    get_merchant_account_id_for_paypal, get_suggested_monthly_upgrade, paypal_macro_fee,
-    paypal_micro_fee
+    determine_paypal_account,
+    freeze_transaction_details_for_session,
+    get_default_currency,
+    get_merchant_account_id_for_paypal,
+    get_min_amount_from_currency_info,
+    get_suggested_monthly_upgrade,
+    paypal_macro_fee,
+    paypal_micro_fee,
 )
 
 
@@ -41,6 +46,46 @@ class UtilsTestCase(TestCase):
     def test_get_suggested_monthly_upgrade_small_single_amount(self):
         self.assertIsNone(get_suggested_monthly_upgrade('usd', Decimal(1)))
         self.assertIsNone(get_suggested_monthly_upgrade('brl', Decimal(1)))
+
+    def test_get_min_amount_from_currency_info_single(self):
+        currency_info = {
+            'minAmount': {
+                'single': 1,
+                'monthly': 2,
+            }
+        }
+
+        result = get_min_amount_from_currency_info(currency_info=currency_info, frequency='single')
+
+        self.assertEqual(result, 1)
+
+    def test_get_min_amount_from_currency_info_monthly(self):
+        currency_info = {
+            'minAmount': {
+                'single': 1,
+                'monthly': 2,
+            }
+        }
+
+        result = get_min_amount_from_currency_info(currency_info=currency_info, frequency='monthly')
+
+        self.assertEqual(result, 2)
+
+    def test_get_min_amount_from_currency_info_missing_frequency(self):
+        currency_info = {
+            'minAmount': {}
+        }
+
+        result = get_min_amount_from_currency_info(currency_info=currency_info, frequency='monthly')
+
+        self.assertEqual(result, 0)
+
+    def test_get_min_amount_from_currency_info_missing_min_amount(self):
+        currency_info = {}
+
+        result = get_min_amount_from_currency_info(currency_info=currency_info, frequency='monthly')
+
+        self.assertEqual(result, 0)
 
     def test_paypal_micro_fee(self):
         self.assertEqual(paypal_micro_fee('usd', Decimal(1)), Decimal('0.11'))

--- a/donate/payments/tests/test_views.py
+++ b/donate/payments/tests/test_views.py
@@ -785,6 +785,7 @@ class CardUpsellViewTestCase(TestCase):
                 'transaction_id': 'subscription-id-1',
                 'payment_method': 'Braintree_Card',
                 'currency': 'usd',
+                'frequency': 'monthly',
                 'payment_frequency': 'monthly',
                 'country': 'US',
                 'first_name': 'Alice',
@@ -907,6 +908,7 @@ class PaypalUpsellViewTestCase(TestCase):
                 'braintree_nonce': 'hello-braintree',
                 'payment_method': 'Braintree_Paypal',
                 'currency': 'usd',
+                'frequency': 'monthly',
                 'payment_frequency': 'monthly',
                 'payment_method_token': 'payment-method-1',
             }

--- a/donate/payments/utils.py
+++ b/donate/payments/utils.py
@@ -61,13 +61,25 @@ def get_suggested_monthly_upgrade(currency, single_amount):
             return Decimal(tier['value'])
 
 
-def get_min_amount_from_currency(currency, frequency):
-    # get currency info
-    # get min amount from currency info
-    pass
+@lru_cache(maxsize=1000)
+def get_min_amount_for_currency(currency, frequency):
+    """
+    Get minimum amount for a given frequency for a given currency.
+
+    Returns 0 if no minimum amount could be determined.
+
+    """
+    currency_info = get_currency_info(currency=currency)
+    return get_min_amount_from_currency_info(currency_info=currency_info, frequency=frequency)
 
 
 def get_min_amount_from_currency_info(currency_info, frequency):
+    """
+    Get minimum amount for a given frequency from a currency info dict.
+
+    Returns 0 if no minimum amount could be determined.
+
+    """
     min_amount_for_frequency = 0
     try:
         min_amounts = currency_info['minAmount']

--- a/donate/payments/utils.py
+++ b/donate/payments/utils.py
@@ -1,3 +1,4 @@
+import logging
 from functools import lru_cache
 from decimal import Decimal
 
@@ -10,6 +11,8 @@ from .constants import (
     PAYPAL_ACCOUNT_MICRO,
     ZERO_DECIMAL_CURRENCIES,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def zero_decimal_currency_fix(amount, currency):
@@ -56,6 +59,22 @@ def get_suggested_monthly_upgrade(currency, single_amount):
     for tier in info.get('monthlyUpgrade', []):
         if Decimal(single_amount) >= tier['min']:
             return Decimal(tier['value'])
+
+
+def get_min_amount_from_currency(currency, frequency):
+    # get currency info
+    # get min amount from currency info
+    pass
+
+
+def get_min_amount_from_currency_info(currency_info, frequency):
+    min_amount_for_frequency = 0
+    try:
+        min_amounts = currency_info['minAmount']
+        min_amount_for_frequency = min_amounts[frequency]
+    except KeyError:
+        logger.exception(msg='Could not determine min amount for frequency.')
+    return min_amount_for_frequency
 
 
 def paypal_micro_fee(currency, amount):

--- a/donate/payments/views.py
+++ b/donate/payments/views.py
@@ -138,7 +138,11 @@ class CardPaymentView(BraintreePaymentMixin, FormView):
         self.payment_frequency = kwargs['frequency']
 
         # Ensure that the donation amount, currency and source page are legit
-        start_form = StartCardPaymentForm(request.GET)
+        start_form_data = {
+            'frequency': self.payment_frequency,
+            **request.GET,
+        }
+        start_form = StartCardPaymentForm(data=start_form_data)
         if not start_form.is_valid():
             return HttpResponseRedirect('/')
 

--- a/donate/payments/views.py
+++ b/donate/payments/views.py
@@ -138,10 +138,8 @@ class CardPaymentView(BraintreePaymentMixin, FormView):
         self.payment_frequency = kwargs['frequency']
 
         # Ensure that the donation amount, currency and source page are legit
-        start_form_data = {
-            'frequency': self.payment_frequency,
-            **request.GET,
-        }
+        start_form_data = request.GET.copy()
+        start_form_data['frequency'] = self.payment_frequency
         start_form = StartCardPaymentForm(data=start_form_data)
         if not start_form.is_valid():
             return HttpResponseRedirect('/')

--- a/donate/payments/views.py
+++ b/donate/payments/views.py
@@ -639,11 +639,6 @@ class CardUpsellView(TransactionRequiredMixin, BraintreePaymentMixin, FormView):
             'currency': self.currency,
         }
 
-    def get_form_kwargs(self):
-        kwargs = super().get_form_kwargs()
-        kwargs['currency'] = self.currency
-        return kwargs
-
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
         ctx['currency_info'] = get_currency_info(self.currency)

--- a/donate/settings/base.py
+++ b/donate/settings/base.py
@@ -201,7 +201,10 @@ class Base(object):
     CURRENCIES = {
         'usd': {
             'code': 'usd',
-            'minAmount': 10,
+            'minAmount': {
+                'single': 10,
+                'monthly': 10,
+            },
             'symbol': '$',
             'paypalFixedFee': {
                 'macro': 0.30,
@@ -222,7 +225,10 @@ class Base(object):
         },
         'aud': {
             'code': 'aud',
-            'minAmount': 10,
+            'minAmount': {
+                'single': 10,
+                'monthly': 10,
+            },
             'symbol': '$',
             'disabled': ['amex'],
             'paypalFixedFee': {
@@ -244,7 +250,10 @@ class Base(object):
         },
         'brl': {
             'code': 'brl',
-            'minAmount': 8,
+            'minAmount': {
+                'single': 8,
+                'monthly': 8,
+            },
             'symbol': 'R$',
             'paypalFixedFee': {
                 'macro': 0.60,
@@ -266,7 +275,10 @@ class Base(object):
         },
         'cad': {
             'code': 'cad',
-            'minAmount': 10,
+            'minAmount': {
+                'single': 10,
+                'monthly': 10,
+            },
             'symbol': '$',
             'disabled': ['amex'],
             'paypalFixedFee': {
@@ -288,7 +300,10 @@ class Base(object):
         },
         'chf': {
             'code': 'chf',
-            'minAmount': 2,
+            'minAmount': {
+                'single': 2,
+                'monthly': 2,
+            },
             'symbol': 'Fr.',
             'disabled': ['amex'],
             'paypalFixedFee': {
@@ -310,7 +325,10 @@ class Base(object):
         },
         'czk': {
             'code': 'czk',
-            'minAmount': 45,
+            'minAmount': {
+                'single': 45,
+                'monthly': 45,
+            },
             'symbol': 'Kč',
             'paypalFixedFee': {
                 'macro': 10.00,
@@ -332,7 +350,10 @@ class Base(object):
         },
         'dkk': {
             'code': 'dkk',
-            'minAmount': 13,
+            'minAmount': {
+                'single': 13,
+                'monthly': 13,
+            },
             'symbol': 'kr',
             'disabled': ['amex'],
             'paypalFixedFee': {
@@ -354,7 +375,10 @@ class Base(object):
         },
         'eur': {
             'code': 'eur',
-            'minAmount': 10,
+            'minAmount': {
+                'single': 10,
+                'monthly': 10,
+            },
             'symbol': '€',
             'disabled': ['amex'],
             'paypalFixedFee': {
@@ -375,7 +399,10 @@ class Base(object):
         },
         'gbp': {
             'code': 'gbp',
-            'minAmount': 10,
+            'minAmount': {
+                'single': 10,
+                'monthly': 10,
+            },
             'symbol': '£',
             'disabled': ['amex'],
             'paypalFixedFee': {
@@ -397,7 +424,10 @@ class Base(object):
         },
         'hkd': {
             'code': 'hkd',
-            'minAmount': 15,
+            'minAmount': {
+                'single': 15,
+                'monthly': 15,
+            },
             'symbol': '$',
             'disabled': ['amex'],
             'paypalFixedFee': {
@@ -419,7 +449,10 @@ class Base(object):
         },
         'huf': {
             'code': 'huf',
-            'minAmount': 570,
+            'minAmount': {
+                'single': 570,
+                'monthly': 570,
+            },
             'symbol': 'Ft',
             'paypalFixedFee': {
                 'macro': 90,
@@ -442,7 +475,10 @@ class Base(object):
         },
         'inr': {
             'code': 'inr',
-            'minAmount': 145,
+            'minAmount': {
+                'single': 145,
+                'monthly': 145,
+            },
             'symbol': '₹',
             'disabled': ['paypal', 'amex'],
             'monthlyUpgrade': [
@@ -460,7 +496,10 @@ class Base(object):
         },
         'jpy': {
             'code': 'jpy',
-            'minAmount': 230,
+            'minAmount': {
+                'single': 230,
+                'monthly': 230,
+            },
             'symbol': '¥',
             'disabled': ['amex'],
             'paypalFixedFee': {
@@ -483,7 +522,10 @@ class Base(object):
         },
         'mxn': {
             'code': 'mxn',
-            'minAmount': 40,
+            'minAmount': {
+                'single': 40,
+                'monthly': 40,
+            },
             'symbol': '$',
             'paypalFixedFee': {
                 'macro': 4.00,
@@ -505,7 +547,10 @@ class Base(object):
         },
         'nok': {
             'code': 'nok',
-            'minAmount': 17,
+            'minAmount': {
+                'single': 17,
+                'monthly': 17,
+            },
             'symbol': 'kr',
             'disabled': ['amex'],
             'paypalFixedFee': {
@@ -527,7 +572,10 @@ class Base(object):
         },
         'nzd': {
             'code': 'nzd',
-            'minAmount': 3,
+            'minAmount': {
+                'single': 3,
+                'monthly': 3,
+            },
             'symbol': '$',
             'disabled': ['amex'],
             'paypalFixedFee': {
@@ -549,7 +597,10 @@ class Base(object):
         },
         'pln': {
             'code': 'pln',
-            'minAmount': 7,
+            'minAmount': {
+                'single': 7,
+                'monthly': 7,
+            },
             'symbol': 'zł',
             'disabled': ['amex'],
             'paypalFixedFee': {
@@ -571,7 +622,10 @@ class Base(object):
         },
         'rub': {
             'code': 'rub',
-            'minAmount': 130,
+            'minAmount': {
+                'single': 130,
+                'monthly': 130,
+            },
             'symbol': '₽',
             'disabled': ['amex'],
             'paypalFixedFee': {
@@ -593,7 +647,10 @@ class Base(object):
         },
         'sek': {
             'code': 'sek',
-            'minAmount': 18,
+            'minAmount': {
+                'single': 18,
+                'monthly': 18,
+            },
             'symbol': 'kr',
             'disabled': ['amex'],
             'paypalFixedFee': {
@@ -615,7 +672,10 @@ class Base(object):
         },
         'twd': {
             'code': 'twd',
-            'minAmount': 62,
+            'minAmount': {
+                'single': 62,
+                'monthly': 62,
+            },
             'symbol': 'NT$',
             'disabled': ['amex'],
             'paypalFixedFee': {

--- a/donate/settings/base.py
+++ b/donate/settings/base.py
@@ -377,7 +377,7 @@ class Base(object):
             'code': 'eur',
             'minAmount': {
                 'single': 10,
-                'monthly': 10,
+                'monthly': 5,
             },
             'symbol': '€',
             'disabled': ['amex'],
@@ -401,7 +401,7 @@ class Base(object):
             'code': 'gbp',
             'minAmount': {
                 'single': 10,
-                'monthly': 10,
+                'monthly': 5,
             },
             'symbol': '£',
             'disabled': ['amex'],

--- a/donate/settings/base.py
+++ b/donate/settings/base.py
@@ -203,7 +203,7 @@ class Base(object):
             'code': 'usd',
             'minAmount': {
                 'single': 10,
-                'monthly': 10,
+                'monthly': 5,
             },
             'symbol': '$',
             'paypalFixedFee': {

--- a/donate/settings/base.py
+++ b/donate/settings/base.py
@@ -216,7 +216,7 @@ class Base(object):
                 {'min': 100, 'value': 10},
                 {'min': 70, 'value': 7},
                 {'min': 35, 'value': 5},
-                {'min': 15, 'value': 3},
+                {'min': 15, 'value': 5},
             ],
             'presets': {
                 'single': [10, 20, 30, 60],
@@ -240,8 +240,8 @@ class Base(object):
                 {'min': 288, 'value': 30},
                 {'min': 144, 'value': 15},
                 {'min': 99, 'value': 10},
-                {'min': 50, 'value': 7},
-                {'min': 22, 'value': 4},
+                {'min': 50, 'value': 10},
+                {'min': 22, 'value': 10},
             ],
             'presets': {
                 'single': [10, 20, 30, 60],
@@ -289,9 +289,9 @@ class Base(object):
                 {'min': 393, 'value': 40},
                 {'min': 262, 'value': 25},
                 {'min': 131, 'value': 12},
-                {'min': 92, 'value': 9},
-                {'min': 46, 'value': 6},
-                {'min': 20, 'value': 4},
+                {'min': 92, 'value': 10},
+                {'min': 46, 'value': 10},
+                {'min': 20, 'value': 10},
             ],
             'presets': {
                 'single': [10, 20, 30, 60],
@@ -414,8 +414,8 @@ class Base(object):
                 {'min': 160, 'value': 15},
                 {'min': 80, 'value': 10},
                 {'min': 56, 'value': 5},
-                {'min': 28, 'value': 4},
-                {'min': 12, 'value': 3},
+                {'min': 28, 'value': 5},
+                {'min': 12, 'value': 5},
             ],
             'presets': {
                 'single': [10, 20, 30, 60],

--- a/donate/settings/thunderbird.py
+++ b/donate/settings/thunderbird.py
@@ -14,7 +14,10 @@ class ThunderbirdOverrides(object):
     CURRENCIES = {
         'usd': {
             'code': 'usd',
-            'minAmount': 2,
+            'minAmount': {
+                'single': 2,
+                'monthly': 2,
+            },
             'symbol': '$',
             'paypalFixedFee': {
                 'macro': 0.30,
@@ -35,7 +38,10 @@ class ThunderbirdOverrides(object):
         },
         'aud': {
             'code': 'aud',
-            'minAmount': 3,
+            'minAmount': {
+                'single': 3,
+                'monthly': 3,
+            },
             'symbol': '$',
             'disabled': ['amex'],
             'paypalFixedFee': {
@@ -57,7 +63,10 @@ class ThunderbirdOverrides(object):
         },
         'brl': {
             'code': 'brl',
-            'minAmount': 8,
+            'minAmount': {
+                'single': 8,
+                'monthly': 8,
+            },
             'symbol': 'R$',
             'paypalFixedFee': {
                 'macro': 0.60,
@@ -79,7 +88,10 @@ class ThunderbirdOverrides(object):
         },
         'cad': {
             'code': 'cad',
-            'minAmount': 3,
+            'minAmount': {
+                'single': 3,
+                'monthly': 3,
+            },
             'symbol': '$',
             'disabled': ['amex'],
             'paypalFixedFee': {
@@ -101,7 +113,10 @@ class ThunderbirdOverrides(object):
         },
         'chf': {
             'code': 'chf',
-            'minAmount': 2,
+            'minAmount': {
+                'single': 2,
+                'monthly': 2,
+            },
             'symbol': 'Fr.',
             'disabled': ['amex'],
             'paypalFixedFee': {
@@ -123,7 +138,10 @@ class ThunderbirdOverrides(object):
         },
         'czk': {
             'code': 'czk',
-            'minAmount': 45,
+            'minAmount': {
+                'single': 45,
+                'monthly': 45,
+            },
             'symbol': 'Kč',
             'paypalFixedFee': {
                 'macro': 10.00,
@@ -145,7 +163,10 @@ class ThunderbirdOverrides(object):
         },
         'dkk': {
             'code': 'dkk',
-            'minAmount': 13,
+            'minAmount': {
+                'single': 13,
+                'monthly': 13,
+            },
             'symbol': 'kr',
             'disabled': ['amex'],
             'paypalFixedFee': {
@@ -167,7 +188,10 @@ class ThunderbirdOverrides(object):
         },
         'eur': {
             'code': 'eur',
-            'minAmount': 2,
+            'minAmount': {
+                'single': 2,
+                'monthly': 2,
+            },
             'symbol': '€',
             'disabled': ['amex'],
             'paypalFixedFee': {
@@ -188,7 +212,10 @@ class ThunderbirdOverrides(object):
         },
         'gbp': {
             'code': 'gbp',
-            'minAmount': 2,
+            'minAmount': {
+                'single': 2,
+                'monthly': 2,
+            },
             'symbol': '£',
             'disabled': ['amex'],
             'paypalFixedFee': {
@@ -210,7 +237,10 @@ class ThunderbirdOverrides(object):
         },
         'hkd': {
             'code': 'hkd',
-            'minAmount': 15,
+            'minAmount': {
+                'single': 15,
+                'monthly': 15,
+            },
             'symbol': '$',
             'disabled': ['amex'],
             'paypalFixedFee': {
@@ -232,7 +262,10 @@ class ThunderbirdOverrides(object):
         },
         'huf': {
             'code': 'huf',
-            'minAmount': 570,
+            'minAmount': {
+                'single': 570,
+                'monthly': 570,
+            },
             'symbol': 'Ft',
             'paypalFixedFee': {
                 'macro': 90,
@@ -255,7 +288,10 @@ class ThunderbirdOverrides(object):
         },
         'inr': {
             'code': 'inr',
-            'minAmount': 145,
+            'minAmount': {
+                'single': 145,
+                'monthly': 145,
+            },
             'symbol': '₹',
             'disabled': ['paypal', 'amex'],
             'monthlyUpgrade': [
@@ -273,7 +309,10 @@ class ThunderbirdOverrides(object):
         },
         'jpy': {
             'code': 'jpy',
-            'minAmount': 230,
+            'minAmount': {
+                'single': 230,
+                'monthly': 230,
+            },
             'symbol': '¥',
             'disabled': ['amex'],
             'paypalFixedFee': {
@@ -296,7 +335,10 @@ class ThunderbirdOverrides(object):
         },
         'mxn': {
             'code': 'mxn',
-            'minAmount': 40,
+            'minAmount': {
+                'single': 40,
+                'monthly': 40,
+            },
             'symbol': '$',
             'paypalFixedFee': {
                 'macro': 4.00,
@@ -318,7 +360,10 @@ class ThunderbirdOverrides(object):
         },
         'nok': {
             'code': 'nok',
-            'minAmount': 17,
+            'minAmount': {
+                'single': 17,
+                'monthly': 17,
+            },
             'symbol': 'kr',
             'disabled': ['amex'],
             'paypalFixedFee': {
@@ -340,7 +385,10 @@ class ThunderbirdOverrides(object):
         },
         'nzd': {
             'code': 'nzd',
-            'minAmount': 3,
+            'minAmount': {
+                'single': 3,
+                'monthly': 3,
+            },
             'symbol': '$',
             'disabled': ['amex'],
             'paypalFixedFee': {
@@ -362,7 +410,10 @@ class ThunderbirdOverrides(object):
         },
         'pln': {
             'code': 'pln',
-            'minAmount': 7,
+            'minAmount': {
+                'single': 7,
+                'monthly': 7,
+            },
             'symbol': 'zł',
             'disabled': ['amex'],
             'paypalFixedFee': {
@@ -384,7 +435,10 @@ class ThunderbirdOverrides(object):
         },
         'rub': {
             'code': 'rub',
-            'minAmount': 130,
+            'minAmount': {
+                'single': 130,
+                'monthly': 130,
+            },
             'symbol': '₽',
             'disabled': ['amex'],
             'paypalFixedFee': {
@@ -406,7 +460,10 @@ class ThunderbirdOverrides(object):
         },
         'sek': {
             'code': 'sek',
-            'minAmount': 18,
+            'minAmount': {
+                'single': 18,
+                'monthly': 18,
+            },
             'symbol': 'kr',
             'disabled': ['amex'],
             'paypalFixedFee': {
@@ -428,7 +485,10 @@ class ThunderbirdOverrides(object):
         },
         'twd': {
             'code': 'twd',
-            'minAmount': 62,
+            'minAmount': {
+                'single': 62,
+                'monthly': 62,
+            },
             'symbol': 'NT$',
             'disabled': ['amex'],
             'paypalFixedFee': {

--- a/donate/templates/fragments/donate_form.html
+++ b/donate/templates/fragments/donate_form.html
@@ -39,13 +39,13 @@
                             <input type="radio" class="donation-amount__radio one-time-amount-donation-radio" name="amount" value="other" id="one-time-amount-other" autocomplete="off" data-other-amount-radio="" {% if initial_amount == "other" %}checked="checked"{% endif %}>
                             <label for="one-time-amount-other" class="donation-amount__label donation-amount-other__label" data-currency="">{% get_localized_currency_symbol initial_currency_info.code %}</label>
                             <label for="one-time-amount-other-input" class="donation-amount__label--hidden">{% trans "Other amount" %}</label>
-                            <input type="number" class="donation-amount__input one-time-amount-other-input OG" id="one-time-amount-other-input" placeholder="{% trans 'Other amount' %}" min="{{ initial_currency_info.minAmount }}" max="10000000" data-other-amount="">
+                            <input type="number" class="donation-amount__input one-time-amount-other-input OG" id="one-time-amount-other-input" placeholder="{% trans 'Other amount' %}" min="{{ initial_currency_info.minAmount.single }}" max="10000000" data-other-amount="">
                         </div>
                         <p class='minimum'>
-                            {% format_currency request.LANGUAGE_CODE initial_currency_info.code initial_currency_info.minAmount as minimum_amount %}
+                            {% format_currency request.LANGUAGE_CODE initial_currency_info.code initial_currency_info.minAmount.single as minimum_amount %}
                             {% block minimum_amount_message %}
                                 {% blocktrans with min_amount=minimum_amount trimmed %}To combat fraud, Mozilla Foundation has temporarily restricted donations to a minimum of {{ min_amount }}{% endblocktrans %}
-                            {% endblock %}
+                            {% endblock minimum_amount_message %}
                         </p>
                         <p id='other-one-time-amount-error-message' class='error-message hidden'>
                             {% trans "Invalid amount entered." %}
@@ -116,10 +116,10 @@
                             <input type="radio" class="donation-amount__radio monthly-amount-donation-radio" name="amount" value="other" id="monthly-amount-other" autocomplete="off" data-other-amount-radio="" {% if initial_amount == "other" %}checked="checked"{% endif %}>
                             <label for="monthly-amount-other" class="donation-amount__label donation-amount-other__label" data-currency="">{% get_localized_currency_symbol initial_currency_info.code %}</label>
                             <label for="monthly-amount-other-input" class="donation-amount__label--hidden">{% trans "Other amount" %}</label>
-                            <input type="number" class="donation-amount__input monthly-amount-other-input" name="monthly-amount-other-input" id="monthly-amount-other-input" min="{{ initial_currency_info.minAmount }}" max="10000000" placeholder="{% trans 'Other amount' %}" data-other-amount="">
+                            <input type="number" class="donation-amount__input monthly-amount-other-input" name="monthly-amount-other-input" id="monthly-amount-other-input" min="{{ initial_currency_info.minAmount.monthly }}" max="10000000" placeholder="{% trans 'Other amount' %}" data-other-amount="">
                         </div>
                         <p class='minimum'>
-                            {% format_currency request.LANGUAGE_CODE initial_currency_info.code initial_currency_info.minAmount as minimum_amount %}
+                            {% format_currency request.LANGUAGE_CODE initial_currency_info.code initial_currency_info.minAmount.monthly as minimum_amount %}
                             {% blocktrans with min_amount=minimum_amount trimmed %}Minimum amount is {{ min_amount }}{% endblocktrans %}
                         </p>
                         <p id='other-monthly-amount-error-message' class='error-message hidden'>

--- a/donate/templates/payment/card_master.html
+++ b/donate/templates/payment/card_master.html
@@ -33,7 +33,21 @@
                         <div class="donation-update__form-item form-item donation-update__amount-input">
                             <label class="donation-update__label form-item__label" for="donation-update">{% trans "Donation Amount" %}</label>
                             <div class="donation-update__currency-symbol">{% get_localized_currency_symbol currency_info.code %}</div>
-                            <input class="donation-update__input form-item__input" id="js-update-donation-value" type="number" name="donation-update" value="{{ form.amount.value }}" step="1" min="{{ currency_info.minAmount }}" max="10000000" required>
+                            <input
+                                class="donation-update__input form-item__input"
+                                id="js-update-donation-value"
+                                type="number"
+                                name="donation-update"
+                                value="{{ form.amount.value }}"
+                                step="1"
+                                {% if payment_frequency == "monthly" %}
+                                    min="{{ currency_info.minAmount.monthly }}"
+                                {% else %}
+                                    min="{{ currency_info.minAmount.single }}"
+                                {% endif %}
+                                max="10000000"
+                                required
+                            />
                         </div>
                         <div class="form-item donation-update__confirm-button">
                             <button class="donation-update__action button button--primary button--large" id="js-update-button">{% trans 'Confirm' %}</button>

--- a/source/js/components/currency-selector.js
+++ b/source/js/components/currency-selector.js
@@ -46,8 +46,9 @@ class CurrencySelect {
   assignValues(selectedData) {
     // Create arrays for monthly and one off based on data
     var oneOffValues = selectedData.presets.single;
+    var oneOffMinAmount = selectedData.minAmount.single;
     var monthlyValue = selectedData.presets.monthly;
-    var minAmount = selectedData.minAmount;
+    var monthlyMinAmount = selectedData.minAmount.monthly;
     var formatter = new Intl.NumberFormat(this.locale, {
       style: "currency",
       currency: selectedData.code.toUpperCase(),
@@ -57,14 +58,14 @@ class CurrencySelect {
     // Create buttons
     this.outputOptions(
       oneOffValues,
-      minAmount,
+      oneOffMinAmount,
       "one-time-amount",
       formatter,
       this.oneOffContainer
     );
     this.outputOptions(
       monthlyValue,
-      minAmount,
+      monthlyMinAmount,
       "monthly-amount",
       formatter,
       this.monthlyContainer


### PR DESCRIPTION
## Description

This PR changes the smallest presets value for monthly donations from 10 to 5 for USD, EUR and GBP. 

This change would have collided with the current min amount for these currencies. 
It was communicated that the desired path to resolve this conflict is to enforce a different minimum amount for monthly than for single donations. 
This PR also includes that change of logic. 

Further more, it was discovered that some of the upsell donation values are below the minimum monthly donation. 
This was raised and discussed in #1711, and the chosen resolution was to raise all upsell amounts that are below the minimum monthly amount to that minimum. 
The different levels are kept, in case we want to re-estabilish the previous values at some point. 


Related PRs/issues mozilla/foundation.mozilla.org#9505 #1711

## Checklist

_Remove unnecessary checks_

**Tests**
- [x] Is the code I'm adding covered by tests?

**Changes in Models:**
- ~~[ ] Did I update or add new fake data?~~
- ~~[ ] Did I squash my migration?~~
- [x] [Are my changes backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- ~~[ ] Is my code documented?~~
- [x] Did I update the documentation? -> Yes, I have added some info about the PayPal/Braintree config that is necessary. 
