### PR TITLE
added fundraise up JS snippet to thunderbird <head> element

### DIFF
--- a/donate/templates/base_master.html
+++ b/donate/templates/base_master.html
@@ -20,6 +20,7 @@
         {% block ga_identifier %}
         <meta name="ga-identifier" content="UA-49796218-32">
         {% endblock %}
+        {% block fundraiseup_script %}{% endblock %}
         {% block meta_tags %}{% endblock %}
 
         <link rel="apple-touch-icon" sizes="180x180" href="{% static '_images/favicon/apple-touch-icon.png' %}">

--- a/donate/thunderbird/templates/base.html
+++ b/donate/thunderbird/templates/base.html
@@ -9,4 +9,16 @@
 {% block datalayer_initial_script %}
 {% endblock %}
 
+{% block fundraiseup_script %}
+  <!-- Fundraise Up: the new standard for online giving -->
+  <script nonce="{{request.csp_nonce}}">(function(w,d,s,n,a){if(!w[n]){var l='call,catch,on,once,set,then,track'
+  .split(','),i,o=function(n){return'function'==typeof n?o.l.push([arguments])&&o
+  :function(){return o.l.push([n,arguments])&&o}},t=d.getElementsByTagName(s)[0],
+  j=d.createElement(s);j.async=!0;j.src='https://cdn.fundraiseup.com/widget/'+a;
+  t.parentNode.insertBefore(j,t);o.s=Date.now();o.v=4;o.h=w.location.href;o.l=[];
+  for(i=0;i<7;i++)o[l[i]]=o(l[i]);w[n]=o}
+  })(window,document,'script','FundraiseUp','ADGJGYAN');</script>
+  <!-- End Fundraise Up -->
+{% endblock %}
+
 {% block title_suffix %} | {% trans 'Give to Thunderbird' context 'Page title' %}{% endblock %}


### PR DESCRIPTION
Related PRs/issues #1713 

This PR introduces a new `{% block %}` called `fundraiseup_script` in the `<head>` element of the base template for both the foundation donate site and thunderbird's. 

This block is populated with the JS snippet needed to render the fundraise up modal on the thunderbird site, and is left blank on the donate site's template.

## Checklist

**Tests**
- ~~[ ] Is the code I'm adding covered by tests?~~

**Changes in Models:**
- ~~[ ] Did I update or add new fake data?~~
- ~~[ ] Did I squash my migration?~~
- ~~[ ] [Are my changes backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?~~

**Documentation:**
- ~~[ ] Is my code documented?~~
- ~~[ ] Did I update the documentation?~~
