### PR TITLE
#9505 Update lowest monthly preset value from 10 to 5 for USD, EUR, and GBP

### DIFF
--- a/donate/settings/base.py
+++ b/donate/settings/base.py
@@ -220,7 +220,7 @@ class Base(object):
             ],
             'presets': {
                 'single': [10, 20, 30, 60],
-                'monthly': [10, 15, 20, 25],
+                'monthly': [5, 15, 20, 25],
             }
         },
         'aud': {
@@ -394,7 +394,7 @@ class Base(object):
             ],
             'presets': {
                 'single': [10, 20, 30, 60],
-                'monthly': [10, 15, 20, 25],
+                'monthly': [5, 15, 20, 25],
             }
         },
         'gbp': {
@@ -419,7 +419,7 @@ class Base(object):
             ],
             'presets': {
                 'single': [10, 20, 30, 60],
-                'monthly': [10, 15, 20, 25]
+                'monthly': [5, 15, 20, 25]
             }
         },
         'hkd': {


### PR DESCRIPTION
I somehow managed to miss it in the previous PR related to #9505 to not update the lowest preset amounts, while that was the whole goal of the ticket.

This PR fixes that oversight and sets the lowest mothly preset for USD, EUR and GBP from 10 to 5.


Related PRs/issues #9505

## Checklist

_Remove unnecessary checks_

**Tests**
- ~~[ ] Is the code I'm adding covered by tests?~~

**Changes in Models:**
- ~~[ ] Did I update or add new fake data?~~
- ~~[ ] Did I squash my migration?~~
- [x] [Are my changes backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- ~~[ ] Is my code documented?~~
- ~~[ ] Did I update the documentation?~~
