### PR TITLE
removed unneeded get_form_kwargs function

### DIFF
--- a/donate/payments/views.py
+++ b/donate/payments/views.py
@@ -739,11 +739,6 @@ class PaypalUpsellView(TransactionRequiredMixin, BraintreePaymentMixin, FormView
             'amount': self.suggested_upgrade
         }
 
-    def get_form_kwargs(self):
-        kwargs = super().get_form_kwargs()
-        kwargs['currency'] = self.currency
-        return kwargs
-
     def form_valid(self, form, send_data_to_basket=True):
         self.currency = form.cleaned_data['currency']
 


### PR DESCRIPTION
Closes #1727 

This PR removes the unneeded `get_form_kwargs` method from the `PaypalUpsellView`, as the changes in #1708 provide everything that is needed.

This fixes the 500 error that was being caused by an unexpected `currency` argument being introduced by `get_form_kwargs`.



**Steps to test:**

1. Check out this branch
2. Make a one-time paypal payment > 20USD using the credentials found in 1password
3. You should get redirected to the upsell form.
4. If everything is working as expected, testing is complete! 