### PR TITLE
prepend `SVB -` to Thunderbird's beneficiary name on 'ways-to-give'

### DIFF
--- a/donate/thunderbird/templates/pages/core/ways_to_give_page.html
+++ b/donate/thunderbird/templates/pages/core/ways_to_give_page.html
@@ -25,7 +25,7 @@
         <b>{% trans "Receiving Bank (Pay to):" %}</b> Standard Chartered Bank<br>
         <b>{% trans "City & Country/Region:" %}</b> {% trans "Frankfurt, Germany" %}<br>
         <b>{% trans "SWIFT/BIC Code:" %}</b> SCBLDEFX<br>
-        <b>{% trans "Beneficiary Name (For credit to):" %}</b> MZLA Technologies Corporation<br>
+        <b>{% trans "Beneficiary Name (For credit to):" %}</b> SVB - MZLA Technologies Corporation<br>
         <b>{% trans "IBAN:" %}</b> DE05512305000500215809
         {% block tb_memo_eur %}<br><b>{% trans "Memo field:" %}</b> Thunderbird{% endblock %}
     </p>


### PR DESCRIPTION
Hey there!

We were notified we needed to add this to our "Ways to Give" page for the Euros section. So here it is!

Let me know if I've missed any required steps for changing templates.

Cheers,
Mel