### PR TITLE
updated heroku plans and review app csp directives

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "name": "donate-wagtail",
   "description": "Donate platform",
   "repository": "https://github.com/mozilla/donate-wagtail",
-  "addons": ["heroku-postgresql:hobby-dev", "heroku-redis:hobby-dev"],
+  "addons": ["heroku-postgresql:mini", "heroku-redis:mini"],
   "buildpacks": [
     {
       "url": "heroku/nodejs"
@@ -35,12 +35,12 @@
     "XSS_PROTECTION": "True",
     "CSRF_COOKIE_SECURE": "True",
     "SESSION_COOKIE_SECURE": "True",
-    "CSP_SCRIPT_SRC": "'self' 'unsafe-inline' 'unsafe-eval' www.google-analytics.com js.braintreegateway.com assets.braintreegateway.com www.paypalobjects.com c.paypal.com www.paypal.com",
-    "CSP_IMG_SRC": "* data:",
-    "CSP_FONT_SRC": "'self' fonts.googleapis.com fonts.gstatic.com",
+    "CSP_SCRIPT_SRC": "'self' 'unsafe-inline' 'unsafe-eval' www.google-analytics.com js.braintreegateway.com assets.braintreegateway.com www.paypalobjects.com *.paypal.com *.fundraiseup.com *.stripe.com m.stripe.network *.plaid.com *.src.mastercard.com *.checkout.visa.com pay.google.com",
+    "CSP_IMG_SRC": "* data: *.fundraiseup.com ucarecdn.com pay.google.com",
+    "CSP_FONT_SRC": "'self' fonts.googleapis.com fonts.gstatic.com *.fundraiseup.com *.stripe.com",
     "CSP_STYLE_SRC": "'self' 'unsafe-inline' fonts.googleapis.com fonts.gstatic.com",
-    "CSP_FRAME_SRC": "'self' assets.braintreegateway.com c.paypal.com *.paypal.com",
-    "CSP_CONNECT_SRC": "'self' api.sandbox.braintreegateway.com client-analytics.sandbox.braintreegateway.com api.braintreegateway.com client-analytics.braintreegateway.com *.braintree-api.com www.paypal.com www.google-analytics.com https://www.mozilla.org/en-US/newsletter/"
+    "CSP_FRAME_SRC": "'self' assets.braintreegateway.com *.paypal.com *.fundraiseup.com *.stripe.com *.plaid.com pay.google.com",
+    "CSP_CONNECT_SRC": "'self' api.sandbox.braintreegateway.com client-analytics.sandbox.braintreegateway.com api.braintreegateway.com client-analytics.braintreegateway.com *.braintree-api.com *.paypal.com www.google-analytics.com https://www.mozilla.org/en-US/newsletter/ fndrsp.net fndrsp-checkout.net *.fundraiseup.com *.stripe.com *.plaid.com *.mastercard.com *.checkout.visa.com api.addressy.com"
   },
   "scripts": {
     "postdeploy": "python manage.py load_fake_data && python manage.py review_app_admin",


### PR DESCRIPTION
Closes #1745


Updates `app.json` to use heroku's "mini" plan for review apps.

Also updates review app's default CSP directives to include URLs required for FundraiseUp to work. 

For CSP reference, see: https://fundraiseup.com/support/content-security-policy/