### PR TITLE
added delayed response notice to foundation donor help page

### DIFF
--- a/donate/templates/pages/core/contributor_support_page.html
+++ b/donate/templates/pages/core/contributor_support_page.html
@@ -1,3 +1,21 @@
 {% extends "pages/core/contributor_support_page_master.html" %}
 
-{# There are no overrides in this template, but alternative apps can template-overide this file (e.g. thunderbird) #}
+{% load i18n %}
+
+
+{% block delayed_response_notice %}
+    <div class="delayed-response-notice">
+        <p>
+            <b>
+            {% blocktrans trimmed %}
+                Our team is experiencing a backlog in donor inquiries. Please expect a delay of up to 5 business days to respond to your inquiry. 
+            {% endblocktrans %}
+            </b>
+        </p>
+        <p>
+            {% blocktrans trimmed %}
+                If you are a current donor, you can use the self-service option to log into your donor portal. You can see receipts and make changes to your monthly gift. To access your log in page, refer to your link in a recent donation email.
+            {% endblocktrans %}
+        </p>
+    </div>
+{% endblock %}

--- a/donate/templates/pages/core/contributor_support_page_master.html
+++ b/donate/templates/pages/core/contributor_support_page_master.html
@@ -49,9 +49,6 @@
     <div class="layout__container">
         <div class="layout__full-col">
             <div class="page-body support-form">
-
-                {% block delayed_response_notice %}
-                {% endblock %}
     
             {% if 'submitted' in request.GET %}
                 <h1 class="heading heading--primary">
@@ -65,6 +62,9 @@
                 </div>
             {% else %}
                 <form action="https://webto.salesforce.com/servlet/servlet.WebToCase?encoding=UTF-8" method="POST">
+
+                    {% block delayed_response_notice %}
+                    {% endblock %}
 
                     {% block donate_support_text %}
                         <p class="rich-text">

--- a/donate/templates/pages/core/contributor_support_page_master.html
+++ b/donate/templates/pages/core/contributor_support_page_master.html
@@ -49,6 +49,10 @@
     <div class="layout__container">
         <div class="layout__full-col">
             <div class="page-body support-form">
+
+                {% block delayed_response_notice %}
+                {% endblock %}
+    
             {% if 'submitted' in request.GET %}
                 <h1 class="heading heading--primary">
                     {% trans "Thank you for contacting us. A case has been created for your issue and we will be in touch shortly." %}

--- a/donate/templates/pages/core/contributor_support_page_master.html
+++ b/donate/templates/pages/core/contributor_support_page_master.html
@@ -49,7 +49,6 @@
     <div class="layout__container">
         <div class="layout__full-col">
             <div class="page-body support-form">
-    
             {% if 'submitted' in request.GET %}
                 <h1 class="heading heading--primary">
                     {% trans "Thank you for contacting us. A case has been created for your issue and we will be in touch shortly." %}

--- a/source/sass/components/_support-form.scss
+++ b/source/sass/components/_support-form.scss
@@ -6,6 +6,16 @@
     @include font-size(l);
   }
 
+  .delayed-response-notice {
+    background-color: $color--light-red;
+    padding: 1em 1.5em 0.5em;
+    margin-bottom: 2em;
+
+    p {
+      @include font-size(m);
+    }
+  }
+
   .privacy-notice {
     margin-bottom: 1em;
   }


### PR DESCRIPTION
# Description
Closes #1759
Link to review page: https://donate-wagta-1759-delay-9l2qh2.herokuapp.com/en-US/donor-help/


This PR adds a delayed response notice to the donate site's "help form" page.



# Screenshots

**Initial page render:**

![Screenshot 2023-08-09 at 15-18-57 Donor Help Donate to Mozilla](https://github.com/MozillaFoundation/donate-wagtail/assets/18314510/a2a1ec13-1b91-4ec3-ad68-7b8eacbe1b34)


**Once form is submitted:**


![Screenshot 2023-08-09 at 15-55-20 Donor Help Donate to Mozilla](https://github.com/MozillaFoundation/donate-wagtail/assets/18314510/18e189b3-b7ee-415e-9e2c-53d19c244a1f)

