### PR TITLE
updated ways to give section

### DIFF
--- a/donate/templates/fragments/donate_form_disclaimer_fundraise_up.html
+++ b/donate/templates/fragments/donate_form_disclaimer_fundraise_up.html
@@ -13,8 +13,8 @@
 
 {% block other_options %}
     <p>
-        {% blocktrans with check_url='/ways-to-give#check' trimmed %}
-            <b>Other ways to give: <a href="{{ check_url }}">Check</a></b>
+        {% blocktrans with ways_to_give_url='https://foundation.mozilla.org/donate/ways-to-give' trimmed %}
+            <b>Other ways to give: <a href="{{ ways_to_give_url }}">Check, Bank Transfer, Stocks</a></b>
         {% endblocktrans %}
     </p>
 {% endblock %}


### PR DESCRIPTION
# Description
Closes #1766
Link to sample test page: https://donate-wagta-1766-updat-8hapdo.herokuapp.com/en-US/


This PR updates the "Other ways to give" section on the footer to: `Other ways to give: Check, Bank Transfer, Stocks` and updates the links URL to `https://foundation.mozilla.org/donate/ways-to-give`.


# Screenshots

Before:
<img width="1304" alt="Screenshot 2023-11-20 at 11 54 52 PM" src="https://github.com/MozillaFoundation/donate-wagtail/assets/18314510/d6f1ec1e-13d4-4432-96cb-8af87b460929">

After:
<img width="1304" alt="Screenshot 2023-11-20 at 11 55 16 PM" src="https://github.com/MozillaFoundation/donate-wagtail/assets/18314510/95e91ad1-d23f-485a-a2b9-f585a33d130a">

