### PR TITLE
updated deprecated links in disclaimer

### DIFF
--- a/donate/templates/fragments/donate_form_disclaimer_fundraise_up.html
+++ b/donate/templates/fragments/donate_form_disclaimer_fundraise_up.html
@@ -21,12 +21,12 @@
 
 {% block faq_contact %}
     <p>
-        {% blocktrans with faq_url='/faq' trimmed %}
+        {% blocktrans with faq_url='https://foundation.mozilla.org/donate/help/#frequently-asked-questions' trimmed %}
             <b>Question donating?</b> Visit our <a href="{{ faq_url }}">FAQ</a> for answers to most common questions.
         {% endblocktrans %}
     </p>
     <p>
-        {% blocktrans with help_url='/help/' trimmed %}
+        {% blocktrans with help_url='https://foundation.mozilla.org/donate/help' trimmed %}
             <b>Need to reach us about your donation?</b> <a href="{{ help_url }}">Contact us</a>.
         {% endblocktrans %}
     </p>


### PR DESCRIPTION
Closes #1768 

![Screenshot 2023-11-28 at 15-10-36 Donate now Donate to Mozilla](https://github.com/MozillaFoundation/donate-wagtail/assets/18314510/87e9c73f-6549-4a2d-b2be-c75dec4489f6)

This PR updates the two links above to now link to the new donate help pages hosted on foundation.mozilla.org
